### PR TITLE
Bump SkiaSharp.Views.Maui version to 2.88.5

### DIFF
--- a/Maui.FreakyEffects/Maui.FreakyEffects/Maui.FreakyEffects.csproj
+++ b/Maui.FreakyEffects/Maui.FreakyEffects/Maui.FreakyEffects.csproj
@@ -52,6 +52,6 @@
 		<Folder Include="Shared\Skeleton\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.5" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This change should fix the problem where PaintSurface of SKCanvasView does not get called on iOS (possibly only 16.5.1 c).